### PR TITLE
Implement the truncate function without node Buffer

### DIFF
--- a/test.js
+++ b/test.js
@@ -208,3 +208,30 @@ test("remove temp directory", function(t) {
     t.end();
   });
 });
+
+// Test the handling of non-BMP chars in UTF-8
+//
+
+test("non-bmp SADDLES the limit", function(t){
+  var str25x = 'a'.repeat(252),
+      name = str25x + '\uD800\uDC00';
+  t.equal(sanitize(name), str25x);
+
+  t.end();
+});
+
+test("non-bmp JUST WITHIN the limit", function(t){
+  var str25x = 'a'.repeat(251),
+      name = str25x + '\uD800\uDC00';
+  t.equal(sanitize(name), name);
+
+  t.end();
+});
+
+test("non-bmp JUST OUTSIDE the limit", function(t){
+  var str25x = 'a'.repeat(253),
+      name = str25x + '\uD800\uDC00';
+  t.equal(sanitize(name), str25x);
+
+  t.end();
+});


### PR DESCRIPTION
For easier and lightweight use in browser.

I can run 'browserify index.js -s fnSanitize -o fn-sanitize.js' to get a version that works in a browser, but it takes in all Buffer-related code and amounts up to 51K uncompressed.

Since "utf8" is the only concern here, it's possible to rewrite the truncate function without Buffer. The end result is a 3.5K uncompressed, much better for client side use.

A slightly modified version is used in https://github.com/carltonf/bilibili-helper/commit/c7a80fe5ae2ab39cf9117a8244e8b22f0bdb0356 . It's used to sanitize downloaded file names which are auto-created from web page content.

All tests have passed and some tests for non-BMP cases are added.