### PR TITLE
Fix absolute path tests on windows, and sanitize trailing periods and spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,15 @@ var illegalRe = /[\/\?<>\\:\*\|":]/g;
 var controlRe = /[\x00-\x1f\x80-\x9f]/g;
 var reservedRe = /^\.+$/;
 var windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+var windowsTrailingRe = /[\. ]+$/;
 
 function sanitize(input, replacement) {
   var sanitized = input
     .replace(illegalRe, replacement)
     .replace(controlRe, replacement)
     .replace(reservedRe, replacement)
-    .replace(windowsReservedRe, replacement);
+    .replace(windowsReservedRe, replacement)
+    .replace(windowsTrailingRe, replacement);
   return truncate(sanitized, 255);
 }
 

--- a/test.js
+++ b/test.js
@@ -139,7 +139,7 @@ function testStringUsingFS(str, t) {
   var filepath = path.join(tempdir, sanitized);
 
   // Should not contain any directories or relative paths
-  t.equal(path.dirname(path.resolve("/abs/path", sanitized)), "/abs/path");
+  t.equal(path.dirname(path.resolve("/abs/path", sanitized)), path.resolve("/abs/path"));
 
   // Should be max 255 bytes
   t.assert(Buffer.byteLength(sanitized) <= 255, "max 255 bytes");

--- a/test.js
+++ b/test.js
@@ -60,6 +60,14 @@ test("restricted codes", function(t) {
   t.end();
 });
 
+// https://msdn.microsoft.com/en-us/library/aa365247(v=vs.85).aspx
+test("restricted suffixes", function(t) {
+  ["mr.", "mr..", "mr ", "mr  "].forEach(function(name) {
+    t.equal(sanitize(name), "mr");
+  });
+  t.end();
+});
+
 test("relative paths", function(t) {
   [".", "..", "./", "../", "/..", "/../", "*.|."].forEach(function(name) {
     t.equal(sanitize(name), "");


### PR DESCRIPTION
See https://msdn.microsoft.com/en-us/library/aa365247(v=vs.85).aspx

(cc @IvanGoncharov)