### PR TITLE
Removed Repeated Colon from RegEx

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@
 
 var truncate = require("truncate-utf8-bytes");
 
-var illegalRe = /[\/\?<>\\:\*\|":]/g;
+var illegalRe = /[\/\?<>\\:\*\|"]/g;
 var controlRe = /[\x00-\x1f\x80-\x9f]/g;
 var reservedRe = /^\.+$/;
 var windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;


### PR DESCRIPTION
This fixes a [warning from lgtm](https://lgtm.com/projects/g/parshap/node-sanitize-filename/snapshot/0607482f275799ba66842663c760a14f599312e9/files/index.js?sort=name&dir=ASC&mode=heatmap) by removing an unnecessary colon from the regular expression.