### PR TITLE
new feature: options.truncate length or cb fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,15 @@ Options:
  return value will be used as the replacement. See [`String.prototype.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)
  for more info.
 
- * `options.truncate`: *optional, number/function, default: `255`*. If passed
- as a number, it's used as the length in truncate call to reduce file name to desired length. 
- If passed as a function, the function will be called with the filename and it's
- return value will be used as the final output value out of sanitize.
- If truncate callback function is specified AND `options.replacement` is non-default,
- then the truncate callback function will be called twice - once during replacement
- (but before sanitization), and once during sanitization.
+ * `options.truncateLength`: *optional, number, default: `255`*. Used in truncate call
+ to reduce string to the specified  length. If <=0, returns ''.
+
+ * `options.preserveFileExt`: *optional, boolean, default: `false`*. By default, 
+ string is trimmed to the `options.truncateLength` length. If true, file extension
+ is preserved within the `options.truncateLength` bounds, unless extension is
+ longer then `options.truncateLength` then the result is just the extension trimmed
+ to the `options.truncateLength` length. Note: extensions is parsed using
+ `path.extname` and as such the leading '.' in the extension name, unless it's a
+ 'dot-file' in which case the extension is empty. Note that one exception is files
+ that end with a "." - such pattern is transformed away using `options.replacement`
+ (default: stripped away).

--- a/README.md
+++ b/README.md
@@ -101,3 +101,11 @@ Options:
  a function, the function will be called with the invalid characters and it's
  return value will be used as the replacement. See [`String.prototype.replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)
  for more info.
+
+ * `options.truncate`: *optional, number/function, default: `255`*. If passed
+ as a number, it's used as the length in truncate call to reduce file name to desired length. 
+ If passed as a function, the function will be called with the filename and it's
+ return value will be used as the final output value out of sanitize.
+ If truncate callback function is specified AND `options.replacement` is non-default,
+ then the truncate callback function will be called twice - once during replacement
+ (but before sanitization), and once during sanitization.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,8 @@ declare function sanitize(
   input: string,
   options?: {
     replacement?: string | ((substring: string) => string);
-    truncate?: number | ((filename: string) => string);
+    truncateLength?: number;
+    preserveFileExt?: boolean;
   }
 ): string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare function sanitize(
   input: string,
   options?: {
     replacement?: string | ((substring: string) => string);
+    truncate?: number | ((filename: string) => string);
   }
 ): string;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5880,9 +5880,9 @@
       "dev": true
     },
     "truncate-utf8-bytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.1.tgz",
-      "integrity": "sha1-uvy/gUxeROwJFok06yNu33Vt6i0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -6083,9 +6083,9 @@
       "dev": true
     },
     "utf8-byte-length": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.3.tgz",
-      "integrity": "sha1-goKpvNzrPH/uLsS9dxVEB7g27e8="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util": {
       "version": "0.10.3",

--- a/test.js
+++ b/test.js
@@ -115,29 +115,18 @@ test("255 characters max", function(t) {
   t.end();
 });
 
-test("custom truncate function", function(t) {
-  var string = repeat("a\u0000 ", 300); // lot's of blank space between characters
-  t.ok(string.length > 255);
-  t.ok(sanitize(string, { truncate: (name) => { // replace whitespace with blank
-    return !name ? name : name.replace(new RegExp(/\s/g), '');
-  }}).length <= 300); // should strip out whitespace
-  t.end();
-});
-
-test("custom truncate function with replacement", function(t) {
-  var string = repeat("x \u0000", 128); // lot's of blank space between characters
-  t.ok(string.length > 10);
-  t.ok(sanitize(string, { replacement: "_", truncate: (name) => { // replace whitespace with blank
-    name = !name ? name : name.replace(new RegExp(/\s/g), '');
-    return name;
-  }}).length == 256); // should replace illegal character \u0000 with underscore and strip excess space
-  t.end();
-});
-
-test("260 characters max", function(t) {
-  var string = repeat("a ", 300);
-  t.ok(string.length > 260);
-  t.ok(sanitize(string, { truncate: 260 }).length <= 260);
+test("variable length, include/exclude file extension", function(t) {
+  t.ok(sanitize("01234567.89A", { truncateLength: 8+1+3 }) == "01234567.89A");
+  t.ok(sanitize("0123456789ABC.DEF", { truncateLength: 8+1+3, preserveFileExt: true }) == "01234567.DEF");
+  t.ok(sanitize("\u000001234567.89ABCDEF", { truncateLength: 8+1+3, preserveFileExt: true }) == "012.89ABCDEF");
+  t.ok(sanitize("\u000001234567.89ABCDEF", { truncateLength: 8+1+3, preserveFileExt: false }) == "01234567.89A");
+  t.ok(sanitize("\u000001234567", { truncateLength: 4, preserveFileExt: true }) == "0123");
+  t.ok(sanitize("\u000001234567.", { truncateLength: 1, preserveFileExt: true }) == "0");
+  t.ok(sanitize("\u000001234567.", { replacement: "XYZ", truncateLength: 2, preserveFileExt: true }) == "XY");
+  t.ok(sanitize("\u000001234567.89ABCDEF", { truncateLength: 0, preserveFileExt: true }) == "");
+  t.ok(sanitize("\u0000", { truncateLength: 255, preserveFileExt: true }) == "");
+  t.ok(sanitize("\u00000123.ABCD", { truncateLength: 4, preserveFileExt: true }) == ".ABC");
+  t.ok(sanitize("01234567.89A", { truncateLength: -12 }) == "");
   t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -115,6 +115,34 @@ test("255 characters max", function(t) {
   t.end();
 });
 
+test("custom truncate function", function(t) {
+  var string = repeat("a\u0000 ", 300); // lot's of blank space between characters
+  t.ok(string.length > 255);
+  t.ok(sanitize(string, { truncate: (name) => { // replace whitespace with blank
+    return !name ? name : name.replace(new RegExp(/\s/g), '');
+  }}).length == 300); // should strip out whitespace
+  t.end();
+});
+
+test("custom truncate function with replacement", function(t) {
+  var string = repeat("x \u0000", 10); // lot's of blank space between characters
+  t.ok(string.length > 10);
+  t.ok(sanitize(string, { replacement: "_", truncate: (name) => { // replace whitespace with blank
+    console.log("******* before: %s", name);
+    name = !name ? name : name.replace(new RegExp(/\s/g), '');
+    console.log("******* after: %s", name);
+    return name;
+  }}).length == 20); // should replace illegal character \u0000 with underscore and strip excess space
+  t.end();
+});
+
+test("260 characters max", function(t) {
+  var string = repeat("a ", 300);
+  t.ok(string.length > 260);
+  t.ok(sanitize(string, { truncate: 260 }).length <= 260);
+  t.end();
+});
+
 // Test the handling of non-BMP chars in UTF-8
 //
 

--- a/test.js
+++ b/test.js
@@ -120,19 +120,17 @@ test("custom truncate function", function(t) {
   t.ok(string.length > 255);
   t.ok(sanitize(string, { truncate: (name) => { // replace whitespace with blank
     return !name ? name : name.replace(new RegExp(/\s/g), '');
-  }}).length == 300); // should strip out whitespace
+  }}).length <= 300); // should strip out whitespace
   t.end();
 });
 
 test("custom truncate function with replacement", function(t) {
-  var string = repeat("x \u0000", 10); // lot's of blank space between characters
+  var string = repeat("x \u0000", 128); // lot's of blank space between characters
   t.ok(string.length > 10);
   t.ok(sanitize(string, { replacement: "_", truncate: (name) => { // replace whitespace with blank
-    console.log("******* before: %s", name);
     name = !name ? name : name.replace(new RegExp(/\s/g), '');
-    console.log("******* after: %s", name);
     return name;
-  }}).length == 20); // should replace illegal character \u0000 with underscore and strip excess space
+  }}).length == 256); // should replace illegal character \u0000 with underscore and strip excess space
   t.end();
 });
 


### PR DESCRIPTION
* [x]  Implemented the new feature
* [x]  Added new tests for the new feature 
* [x]  Added new TypeScript type declarations
* [x]  updated jsdoc documentation
* [x]  updated readme

I tried to minimize the amount of additions and to stay in line with the other code, but some unavoidable conflicts will occur with [PR#58](https://github.com/parshap/node-sanitize-filename/pull/58) that defines additional options.

Motivation is simple - I have to produce less then 255 character filenames, I don't want to strip file extensions, and I like to map extra lengthy sentences into filenames by stripping white-space, punctuation, and vowels to make for compact filenames without loss of information (for humans at least).